### PR TITLE
make KAFKA_ADVERTISED_HOST_NAME to be the container ip to make sure i…

### DIFF
--- a/start-kafka.sh
+++ b/start-kafka.sh
@@ -19,7 +19,7 @@ if [[ -n "$KAFKA_HEAP_OPTS" ]]; then
     unset KAFKA_HEAP_OPTS
 fi
 
-export KAFKA_ADVERTISED_HOST_NAME=$DOCKERCLOUD_CONTAINER_HOSTNAME
+export KAFKA_ADVERTISED_HOST_NAME=`curl -s http://rancher-metadata/latest/self/container/primary_ip`
 
 for VAR in `env`
 do

--- a/start-kafka.sh
+++ b/start-kafka.sh
@@ -19,7 +19,7 @@ if [[ -n "$KAFKA_HEAP_OPTS" ]]; then
     unset KAFKA_HEAP_OPTS
 fi
 
-export KAFKA_ADVERTISED_HOST_NAME=`curl -s http://rancher-metadata/latest/self/container/primary_ip`
+export KAFKA_ADVERTISED_HOST_NAME=`ip addr | grep inet | grep 10.42 | tail -1 | awk '{print $2}' | awk -F\/ '{print $1}'`
 
 for VAR in `env`
 do

--- a/start-kafka.sh
+++ b/start-kafka.sh
@@ -19,7 +19,7 @@ if [[ -n "$KAFKA_HEAP_OPTS" ]]; then
     unset KAFKA_HEAP_OPTS
 fi
 
-export KAFKA_ADVERTISED_HOST_NAME=`ip addr | grep inet | grep 10.42 | tail -1 | awk '{print $2}' | awk -F\/ '{print $1}'`
+export KAFKA_ADVERTISED_HOST_NAME=$(ip addr | grep inet | grep 10.42 | tail -1 | awk '{print $2}' | awk -F\/ '{print $1}')
 
 for VAR in `env`
 do

--- a/start-kafka.sh
+++ b/start-kafka.sh
@@ -19,6 +19,8 @@ if [[ -n "$KAFKA_HEAP_OPTS" ]]; then
     unset KAFKA_HEAP_OPTS
 fi
 
+KAFKA_ADVERTISED_HOST_NAME=$(ip addr | grep inet | grep 10.42 | tail -1 | awk '{print $2}' | awk -F\/ '{print $1}')
+
 for VAR in `env`
 do
   if [[ $VAR =~ ^KAFKA_ && ! $VAR =~ ^KAFKA_HOME ]]; then
@@ -34,10 +36,7 @@ done
 
 # remove broker.id
 sed -i.bak '/^broker.id=/d' /opt/kafka_2.11-0.10.0.0/config/server.properties
-sed -i.bak '/^advertised.host.name=.*?' /opt/kafka_2.11-0.10.0.0/config/server.properties
 echo "delete.topic.enable=true" >> /opt/kafka_2.11-0.10.0.0/config/server.properties
-KAFKA_ADVERTISED_HOST_NAME=$(ip addr | grep inet | grep 10.42 | tail -1 | awk '{print $2}' | awk -F\/ '{print $1}')
-echo "advertised.host.name=$KAFKA_ADVERTISED_HOST_NAME" >> /opt/kafka_2.11-0.10.0.0/config/server.properties
 
 KAFKA_PID=0
 

--- a/start-kafka.sh
+++ b/start-kafka.sh
@@ -19,8 +19,6 @@ if [[ -n "$KAFKA_HEAP_OPTS" ]]; then
     unset KAFKA_HEAP_OPTS
 fi
 
-export KAFKA_ADVERTISED_HOST_NAME=$(ip addr | grep inet | grep 10.42 | tail -1 | awk '{print $2}' | awk -F\/ '{print $1}')
-
 for VAR in `env`
 do
   if [[ $VAR =~ ^KAFKA_ && ! $VAR =~ ^KAFKA_HOME ]]; then
@@ -36,7 +34,10 @@ done
 
 # remove broker.id
 sed -i.bak '/^broker.id=/d' /opt/kafka_2.11-0.10.0.0/config/server.properties
+sed -i.bak '/^advertised.host.name=.*?' /opt/kafka_2.11-0.10.0.0/config/server.properties
 echo "delete.topic.enable=true" >> /opt/kafka_2.11-0.10.0.0/config/server.properties
+KAFKA_ADVERTISED_HOST_NAME=$(ip addr | grep inet | grep 10.42 | tail -1 | awk '{print $2}' | awk -F\/ '{print $1}')
+echo "advertised.host.name=$KAFKA_ADVERTISED_HOST_NAME" >> /opt/kafka_2.11-0.10.0.0/config/server.properties
 
 KAFKA_PID=0
 

--- a/start-kafka.sh
+++ b/start-kafka.sh
@@ -19,8 +19,6 @@ if [[ -n "$KAFKA_HEAP_OPTS" ]]; then
     unset KAFKA_HEAP_OPTS
 fi
 
-KAFKA_ADVERTISED_HOST_NAME=$(ip addr | grep inet | grep 10.42 | tail -1 | awk '{print $2}' | awk -F\/ '{print $1}')
-
 for VAR in `env`
 do
   if [[ $VAR =~ ^KAFKA_ && ! $VAR =~ ^KAFKA_HOME ]]; then
@@ -36,7 +34,10 @@ done
 
 # remove broker.id
 sed -i.bak '/^broker.id=/d' /opt/kafka_2.11-0.10.0.0/config/server.properties
+sed -i.bak '/^advertised.host.name=.*?' /opt/kafka_2.11-0.10.0.0/config/server.properties
 echo "delete.topic.enable=true" >> /opt/kafka_2.11-0.10.0.0/config/server.properties
+KAFKA_ADVERTISED_HOST_NAME=$(ip addr | grep inet | grep 10.42 | tail -1 | awk '{print $2}' | awk -F\/ '{print $1}')
+echo "advertised.host.name=$KAFKA_ADVERTISED_HOST_NAME" >> /opt/kafka_2.11-0.10.0.0/config/server.properties
 
 KAFKA_PID=0
 


### PR DESCRIPTION
…t can work in a cluster mode

We have to try this because, kafka sever can not accpet `_` as part of its hostname, while rancher will create a container with name containing `_`
